### PR TITLE
Fix strange issue where low-method links could be used for higher-level method calls

### DIFF
--- a/src/AbstractMySqlGateway.php
+++ b/src/AbstractMySqlGateway.php
@@ -31,7 +31,7 @@ use ObjectivePHP\Gateway\ResultSet\ResultSetInterface;
 abstract class AbstractMySqlGateway extends AbstractPaginableGateway
 {
     /**
-     * @var Link[]
+     * @var Link[][]
      */
     protected $links;
 
@@ -59,7 +59,8 @@ abstract class AbstractMySqlGateway extends AbstractPaginableGateway
         $links = [];
 
         foreach ($this->links as $key => $pool) {
-            if ($method & $key) {
+            // a PERSIST-only link won't be selected for general WRITE
+            if ($method & $key && $key >= $method) {
                 /** @var Link $link */
                 foreach ($pool as $link) {
                     if ($link->runFilters()) {


### PR DESCRIPTION
Changes: 
 - fixed a suspected bug. It allowed getLinks to return GatewayInterface::FETCH_* registered methods to be returned when looking for  GatewayInterface::ALL links